### PR TITLE
bypass xmlcreation

### DIFF
--- a/shiba/inventorymanagement.py
+++ b/shiba/inventorymanagement.py
@@ -46,13 +46,16 @@ class InventoryManagement(object):
         obj = retrieve_obj_from_url(url)
         return obj
 
-    def generic_import_file(self, data):
+    def generic_import_file(self, data,skip=False):
         """Import XML file to your PriceMinister inventory trough a POST request.
 
         :param data: must be a object/dict (OrderedDict is better) containing your inventory wished to be imported. \
         You must respect the XML hierarchy detailed from the WebService documentation inside the object/dict
         """
-        data = create_xml_from_item_obj(data)
+        if skip is False:
+            data = create_xml_from_item_obj(data)
+        else:
+            data = data
         inf = inf_constructor(self.connection, "genericimportfile")
         url = url_constructor(self.connection, inf)
         obj = retrieve_obj_from_url(url, data)

--- a/shiba/inventorymanagement.py
+++ b/shiba/inventorymanagement.py
@@ -51,6 +51,7 @@ class InventoryManagement(object):
 
         :param data: must be a object/dict (OrderedDict is better) containing your inventory wished to be imported. \
         You must respect the XML hierarchy detailed from the WebService documentation inside the object/dict
+        :para skip: with this parameter to True, you could directly send xml according to the XML hierarchy detailed from the WebService documentation
         """
         if skip is False:
             data = create_xml_from_item_obj(data)


### PR DESCRIPTION
Hello, could you valid this pull request please ? The goal is to bypass xml creation with xmltodict (create_xml_from_item_obj) in case XML is already formatted during our own products treatment.

So now accepted formats could be, object, etree element or any other XML :-)

Thanks
